### PR TITLE
Use mktemp for temporary signed.crt file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,10 @@ for example script).
 Example of a `renew_cert.sh`:
 ```sh
 #!/usr/bin/sh
-python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > /tmp/signed.crt || exit
-wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > intermediate.pem
-cat /tmp/signed.crt intermediate.pem > /path/to/chained.pem
+SIGNEDCRT=$(mktemp)
+python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > $SIGNEDCRT || exit
+wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem >> $SIGNEDCRT
+mv $SIGNEDCRT /path/to/chained.pem
 service nginx reload
 ```
 


### PR DESCRIPTION
Also avoid unnecessary temporary file for the intermediate certificate.

Resolves #112
